### PR TITLE
[upgrade] Upgrade the version of csi-attacher to v4.4.2

### DIFF
--- a/vcontainer-storage-interface/values.yaml
+++ b/vcontainer-storage-interface/values.yaml
@@ -8,7 +8,7 @@ csi:
   attacher:
     image:
       repository: registry.vngcloud.vn/public/csi-attacher
-      tag: v4.2.0
+      tag: v4.4.2
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}


### PR DESCRIPTION
- Currently, the plugin is using `v4.2.0`, for the cluster of Kubernetes v1.27, use version `v4.4.2` for more stable.